### PR TITLE
Improve support for Goblin Mortar in GearBars

### DIFF
--- a/code/GM_Tooltip.lua
+++ b/code/GM_Tooltip.lua
@@ -45,13 +45,15 @@ function me.UpdateTooltipForItem(item)
   if mod.configuration.IsSimpleTooltipsEnabled() then
     me.BuildSimpleTooltip(tooltip, item.itemId)
   else
-    local _, itemLink = GetItemInfo(item.itemId)
-
-    if item.enchantId ~= nil then
-      itemLink = "item:".. item.itemId .. ":" .. item.enchantId
+    if (item.bag and item.slot) then
+      tooltip:SetBagItem(item.bag, item.slot)
+    else
+      local _, itemLink = GetItemInfo(item.itemId)
+      if item.enchantId ~= nil then
+        itemLink = "item:" .. item.itemId .. ":" .. item.enchantId
+      end
+      tooltip:SetHyperlink(itemLink)
     end
-
-    tooltip:SetHyperlink(itemLink)
     me.AddRuneToTooltip(tooltip, item.runeName)
   end
 

--- a/gui/GM_GearBarChangeMenu.lua
+++ b/gui/GM_GearBarChangeMenu.lua
@@ -182,6 +182,8 @@ function me.UpdateChangeSlot(changeSlot, gearSlotMetaData, item, changeSlotSize)
   changeSlot.itemId = item.id
   changeSlot.equipSlot = item.equipSlot
   changeSlot.enchantId = item.enchantId
+  changeSlot.bag = item.bag
+  changeSlot.slot = item.slot
   changeSlot.runeAbilityId = (item.rune and item.rune.skillLineAbilityID) or nil
   changeSlot.runeName = (item.rune and item.rune.name) or nil
 

--- a/gui/GM_GearBarChangeMenu.lua
+++ b/gui/GM_GearBarChangeMenu.lua
@@ -329,8 +329,8 @@ end
 function me.UpdateChangeMenuGearSlotCooldown()
   for _, changeMenuSlot in pairs(changeMenuSlots) do
     if changeMenuSlot.itemId ~= nil then
-      if changeMenuFrame.showCooldowns then
-        local startTime, duration = C_Container.GetItemCooldown(changeMenuSlot.itemId)
+      local startTime, duration = C_Container.GetItemCooldown(changeMenuSlot.itemId)
+      if changeMenuFrame.showCooldowns and startTime then
         CooldownFrame_Set(changeMenuSlot.cooldownOverlay, startTime, duration, true)
       else
         CooldownFrame_Clear(changeMenuSlot.cooldownOverlay)


### PR DESCRIPTION
This PR fixes two issues:

1. having an empty Goblin Mortar in your inventory breaks GearMenu completely (the change menu doesn't open at all)
2. it is impossible to see how many charges a Goblin Mortar has before equipping it

I am not sure I fixed the second issue the most optimal way but I've been playing with a manually-patched version of GearMenu for a few weeks on anniversary realms and I've not had issues.

Tooltip without patch:
![image](https://github.com/user-attachments/assets/2f4f8567-e91d-4f3f-8375-60facd8422eb)

With patch:
![image](https://github.com/user-attachments/assets/1a317bd0-9a41-47dc-b5e3-69b6fdab9874)
