### PR TITLE
Fix 108: Add nil checks for cooldown start time and duration in tooltip

### DIFF
--- a/gui/GM_GearBarChangeMenu.lua
+++ b/gui/GM_GearBarChangeMenu.lua
@@ -333,7 +333,10 @@ function me.UpdateChangeMenuGearSlotCooldown()
     if changeMenuSlot.itemId ~= nil then
       if changeMenuFrame.showCooldowns then
         local startTime, duration = C_Container.GetItemCooldown(changeMenuSlot.itemId)
-        CooldownFrame_Set(changeMenuSlot.cooldownOverlay, startTime, duration, true)
+
+        if startTime and duration then
+          CooldownFrame_Set(changeMenuSlot.cooldownOverlay, startTime, duration, true)
+        end
       else
         CooldownFrame_Clear(changeMenuSlot.cooldownOverlay)
       end


### PR DESCRIPTION
This fixes #108 thanks @its-riece for bringing this up